### PR TITLE
feat(fromNow()): add a fromNow method

### DIFF
--- a/src/__tests__/relative-time.spec.ts
+++ b/src/__tests__/relative-time.spec.ts
@@ -1,0 +1,113 @@
+import { dayjsNow } from "..";
+import { fromNow } from "../from-now";
+
+describe("fromNow() returns numbers for singular unit durations", () => {
+  it("returns 'a few seconds ago' for duration of 1 second", () => {
+    const now = dayjsNow();
+    const from = now.subtract(1, "second");
+    const res = fromNow(from);
+    expect(res).toEqual("a few seconds ago");
+  });
+
+  it("returns '1 minute ago' for duration of 1 minute", () => {
+    const now = dayjsNow();
+    const from = now.subtract(1, "minute");
+    const res = fromNow(from);
+    expect(res).toEqual("1 minute ago");
+  });
+
+  it("returns '1 hour ago' for duration of 1 hour", () => {
+    const now = dayjsNow();
+    const from = now.subtract(1, "hour");
+    const res = fromNow(from);
+    expect(res).toEqual("1 hour ago");
+  });
+
+  it("returns '1 day ago' for duration of 1 day", () => {
+    const now = dayjsNow();
+    const from = now.subtract(1, "day");
+    const res = fromNow(from);
+    expect(res).toEqual("1 day ago");
+  });
+
+  it("returns '1 month ago' for duration of 1 month", () => {
+    const now = dayjsNow();
+    const from = now.subtract(1, "month");
+    const res = fromNow(from);
+    expect(res).toEqual("1 month ago");
+  });
+
+  it("returns '1 year ago' for duration of 1 year", () => {
+    const now = dayjsNow();
+    const from = now.subtract(1, "year");
+    const res = fromNow(from);
+    expect(res).toEqual("1 year ago");
+  });
+});
+
+describe("fromNow() returns numbers for NON singular unit durations", () => {
+  it("returns 'a few seconds ago' for duration of 10 seconds", () => {
+    const now = dayjsNow();
+    const from = now.subtract(10, "second");
+    const res = fromNow(from);
+    expect(res).toEqual("a few seconds ago");
+  });
+
+  it("returns '10 minutes ago' for duration of 10 minutes", () => {
+    const now = dayjsNow();
+    const from = now.subtract(10, "minute");
+    const res = fromNow(from);
+    expect(res).toEqual("10 minutes ago");
+  });
+
+  it("returns '10 hours ago' for duration of 10 hours", () => {
+    const now = dayjsNow();
+    const from = now.subtract(10, "hour");
+    const res = fromNow(from);
+    expect(res).toEqual("10 hours ago");
+  });
+
+  it("returns '5 days ago' for duration of 5 days", () => {
+    const now = dayjsNow();
+    const from = now.subtract(5, "day");
+    const res = fromNow(from);
+    expect(res).toEqual("5 days ago");
+  });
+
+  it("returns '3 months ago' for duration of 3 months", () => {
+    const now = dayjsNow();
+    const from = now.subtract(3, "month");
+    const res = fromNow(from);
+    expect(res).toEqual("3 months ago");
+  });
+
+  it("returns '3 years ago' for duration of 3 years", () => {
+    const now = dayjsNow();
+    const from = now.subtract(3, "year");
+    const res = fromNow(from);
+    expect(res).toEqual("3 years ago");
+  });
+});
+
+describe("fromNow() optionally adds the default suffix", () => {
+  it("returns '10 minutes' for duration of 10 minutes and withoutSuffix = true", () => {
+    const now = dayjsNow();
+    const from = now.subtract(10, "minute");
+    const res = fromNow(from, true);
+    expect(res).toEqual("10 minutes");
+  });
+
+  it("returns '10 minutes' for duration of 10 minutes and withoutSuffix = false", () => {
+    const now = dayjsNow();
+    const from = now.subtract(10, "minute");
+    const res = fromNow(from, true);
+    expect(res).toEqual("10 minutes");
+  });
+
+  it("suffix is enabled by default", () => {
+    const now = dayjsNow();
+    const from = now.subtract(10, "minute");
+    const res = fromNow(from);
+    expect(res).toEqual("10 minutes ago");
+  });
+});

--- a/src/base.ts
+++ b/src/base.ts
@@ -18,10 +18,12 @@ import "dayjs/plugin/minMax";
 import "dayjs/plugin/relativeTime";
 import "dayjs/plugin/utc";
 import "dayjs/plugin/weekOfYear";
+import "dayjs/plugin/updateLocale";
 
 import advancedFormat from "dayjs/plugin/advancedFormat";
 import durationPlugin, { Duration, DurationUnitsObjectType, DurationUnitType } from "dayjs/plugin/duration";
 import isBetween from "dayjs/plugin/isBetween";
+import updateLocale from "dayjs/plugin/updateLocale";
 import isSameOrAfter from "dayjs/plugin/isSameOrAfter";
 import isSameOrBefore from "dayjs/plugin/isSameOrBefore";
 import minMax from "dayjs/plugin/minMax";
@@ -40,6 +42,7 @@ dayjs.extend(minMax);
 dayjs.extend(relativeTime);
 dayjs.extend(utc);
 dayjs.extend(weekOfYear);
+dayjs.extend(updateLocale);
 
 // exporting the type
 export { Dayjs, Duration, DurationUnitsObjectType, DurationUnitType };

--- a/src/from-now.ts
+++ b/src/from-now.ts
@@ -1,0 +1,16 @@
+import dayjs from "dayjs";
+import { AvailableLocales, Dayjs } from "./base";
+import { relativeTimeConfig } from "./relative-time";
+
+dayjs.updateLocale(AvailableLocales.EnglishAU, { relativeTime: relativeTimeConfig });
+dayjs.updateLocale(AvailableLocales.EnglishCA, { relativeTime: relativeTimeConfig });
+dayjs.updateLocale(AvailableLocales.EnglishGB, { relativeTime: relativeTimeConfig });
+dayjs.updateLocale(AvailableLocales.EnglishIE, { relativeTime: relativeTimeConfig });
+dayjs.updateLocale(AvailableLocales.EnglishIL, { relativeTime: relativeTimeConfig });
+dayjs.updateLocale(AvailableLocales.EnglishNZ, { relativeTime: relativeTimeConfig });
+dayjs.updateLocale(AvailableLocales.EnglishSG, { relativeTime: relativeTimeConfig });
+dayjs.updateLocale(AvailableLocales.EnglishUSA, { relativeTime: relativeTimeConfig });
+
+export function fromNow(value: Dayjs, withoutSuffix?: boolean): string {
+  return value.fromNow(withoutSuffix);
+}

--- a/src/relative-time.ts
+++ b/src/relative-time.ts
@@ -1,0 +1,15 @@
+export const relativeTimeConfig = {
+  future: "in %s",
+  past: "%s ago",
+  s: "a few seconds",
+  m: "1 minute",
+  mm: "%d minutes",
+  h: "1 hour",
+  hh: "%d hours",
+  d: "1 day",
+  dd: "%d days",
+  M: "1 month",
+  MM: "%d months",
+  y: "1 year",
+  yy: "%d years",
+};


### PR DESCRIPTION
add a fromNow method that encapsulates configuration of relativeTime for AvailableLocales

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)



* **What is the current behavior?** (You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)?**



* **Other information**:
